### PR TITLE
Misc fixes

### DIFF
--- a/Unlisted Firearms/Pistols/Zip22.json
+++ b/Unlisted Firearms/Pistols/Zip22.json
@@ -4,7 +4,7 @@
     "copy-from": "pistol_base",
     "looks_like": "box",
     "type": "GUN",
-    "name": { "str": "Zip .22" },
+    "name": { "str": "ZiP .22" },
     "description": "A weird little box that is extremely difficult to shoot, uncomfortable and generally useless.",
     "weight": "430 g",
     "volume": "300 ml",
@@ -19,7 +19,16 @@
     "range": 1,
     "dispersion": 600,
     "durability": 3,
-    "min_cycle_recoil": 40,
+    "min_cycle_recoil": 999,
+    "//": "It's meant to fail on every shot",
+    "faults": [
+      "fault_gun_blackpowder",
+      "fault_gun_dirt",
+      "fault_gun_chamber_spent",
+      "fault_fail_to_feed",
+      "fault_stovepipe",
+      "fault_double_feed"
+    ],
     "flags": [ "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
     "pocket_data": [
       {

--- a/Unlisted Firearms/Pistols/Zip22.json
+++ b/Unlisted Firearms/Pistols/Zip22.json
@@ -12,7 +12,6 @@
     "barrel_length": "133 mm",
     "price": "199 USD",
     "price_postapoc": "1 USD",
-    "variant_type": "gun",
     "material": [ "plastic" ],
     "symbol": "(",
     "color": "dark_gray",
@@ -20,13 +19,22 @@
     "range": 1,
     "dispersion": 600,
     "durability": 3,
-    "min_cycle_recoil": 380,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
+    "min_cycle_recoil": 40,
+    "flags": [ "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
     "pocket_data": [
       {
-        "magazine_well": "250 ml",
+        "magazine_well": "34 ml",
         "pocket_type": "MAGAZINE_WELL",
-        "item_restriction": [ "ruger1022mag" ]
+        "item_restriction": [
+          "ruger1022mag",
+          "ruger1022mag_15",
+          "ruger1022bigmag",
+          "ruger1022mag_30",
+          "ruger1022mag_32",
+          "ruger1022mag_55",
+          "ruger1022mag_70",
+          "ruger1022mag_110"
+        ]
       }
     ],
     "melee_damage": { "bash": 8 }

--- a/Unlisted Firearms/Rifles/FAMAS.json
+++ b/Unlisted Firearms/Rifles/FAMAS.json
@@ -9,6 +9,7 @@
     "weight": "3610 g",
     "volume": "3429 ml",
     "longest_side": "759 mm",
+    "barrel_length": "483 mm",
     "price": "2800000 USD",
     "price_postapoc": "2500 USD",
     "to_hit": -1,
@@ -16,7 +17,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "223" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -2 },
     "dispersion": 180,
     "durability": 8,
     "min_cycle_recoil": 1350,
@@ -46,10 +46,25 @@
           "stanag10ranger",
           "stanag20",
           "stanag20ranger",
-          "stanag30ranger"
+          "stanag30ranger",
+          "stanag40",
+          "stanag40ranger",
+          "stanag50",
+          "stanag60",
+          "stanag60drum",
+          "stanag90",
+          "stanag100",
+          "stanag100drum",
+          "stanag150",
+          "stanag20_beowulf",
+          "stanag20ranger_beowulf",
+          "stanag30_beowulf",
+          "stanag30ranger_beowulf",
+          "survivor223mag"
         ]
       }
     ],
-	"melee_damage": { "bash": 12 }
+    "//": "The IRL gun doesn't take regular STANAGs, but adding in separate magazines would make it way more of a hassle to get it working",
+    "melee_damage": { "bash": 12 }
   }
 ]

--- a/Unlisted Firearms/Rifles/FAMAS.json
+++ b/Unlisted Firearms/Rifles/FAMAS.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "famas",
+    "id": "mas223",
     "copy-from": "rifle_auto",
     "looks_like": "modular_ar15",
     "type": "GUN",

--- a/Unlisted Firearms/Rifles/FN2000.json
+++ b/Unlisted Firearms/Rifles/FN2000.json
@@ -9,6 +9,7 @@
     "weight": "3600 g",
     "volume": "7986 ml",
     "longest_side": "740 mm",
+    "barrel_length": "443 mm",
     "price": 125000,
     "price_postapoc": 2000,
     "to_hit": -1,
@@ -16,7 +17,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "223" ],
-    "ranged_damage": { "damage_type": "stab", "amount": -2 },
     "dispersion": 150,
     "durability": 9,
     "min_cycle_recoil": 1350,
@@ -41,10 +41,24 @@
           "stanag10ranger",
           "stanag20",
           "stanag20ranger",
-          "stanag30ranger"
+          "stanag30ranger",
+          "stanag40",
+          "stanag40ranger",
+          "stanag50",
+          "stanag60",
+          "stanag60drum",
+          "stanag90",
+          "stanag100",
+          "stanag100drum",
+          "stanag150",
+          "stanag20_beowulf",
+          "stanag20ranger_beowulf",
+          "stanag30_beowulf",
+          "stanag30ranger_beowulf",
+          "survivor223mag"
         ]
       }
     ],
-	"melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12 }
   }
 ]


### PR DESCRIPTION
Zip .22 can take any ruger 10/22 magazine, that's pretty much the only useful part of it. Also made it so that it will have faults and always fail. And a name fix, just for good measure.

Added barrel lengths and the rest of the stanag magazines to the two rifles, as a few were missing. Also removed the ranged damage malus, as that should now be handled by the ammo and barrel length. 

Due to the FAMAS id being used in a migration, any time you load the game it will be migrated to the Kel Tec RDB. I got around this by changing the ID to something not used
Testing:
![image](https://github.com/user-attachments/assets/8397ba63-cbe6-4837-8a92-a3741e295eeb)
![image](https://github.com/user-attachments/assets/b78ada7c-5cd8-4cc5-b84a-3d0275e7d6f2)

