### PR TITLE
Adds SKS-M and 1895

### DIFF
--- a/Unlisted Firearms/Itemgroups/itemgroups.json
+++ b/Unlisted Firearms/Itemgroups/itemgroups.json
@@ -46,5 +46,47 @@
     "id": "guns_rifle_common_display_223",
     "copy-from": "guns_rifle_common_display_223",
     "extend": { "items": [ { "item": "fn2000", "prob": 5 }, { "item": "mas223", "prob": 5 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_common_762R",
+    "copy-from": "guns_rifle_common_762R",
+    "extend": { "items": [ { "item": "russian_1895", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_common_worn_762R",
+    "copy-from": "guns_rifle_common_worn_762R",
+    "extend": { "items": [ { "item": "russian_1895", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_rare_762R",
+    "copy-from": "guns_rifle_rare_762R",
+    "extend": { "items": [ { "item": "russian_1895", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_rare_display_762R",
+    "copy-from": "guns_rifle_rare_display_762R",
+    "extend": { "items": [ { "item": "russian_1895", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_common_762",
+    "copy-from": "guns_rifle_common_762",
+    "extend": { "items": [ { "item": "sksm", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_common_worn_762",
+    "copy-from": "guns_rifle_common_worn_762",
+    "extend": { "items": [ { "item": "sksm", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_common_display_762",
+    "copy-from": "guns_rifle_common_display_762",
+    "extend": { "items": [ { "item": "sksm", "prob": 4 } ] }
   }
 ]

--- a/Unlisted Firearms/Rifles/Russian 1895.json
+++ b/Unlisted Firearms/Rifles/Russian 1895.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "GUN",
+    "reload_noise_volume": 10,
+    "handling": 20,
+    "name": { "str": "Russian contract 1895" },
+    "symbol": "(",
+    "color": "brown",
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "copy-from": "rifle_manual",
+    "skill": "rifle",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "bayonet lug", 1 ],
+      [ "brass catcher", 1 ],
+      [ "grip mount", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock mount", 1 ],
+      [ "stock accessory", 2 ],
+      [ "underbarrel", 1 ]
+    ],
+    "id": "russian_1895",
+    "looks_like": "modular_ar15",
+    "description": "The Winchester 1895 was a revolutionary lever action rifle by none other than John Browning.  It was able to fire spitzer bullets unlike most lever actions due to its box magazine.  After rejection from the US Army, a contract to make them in 7.62x54mmR was in order.  While Russia soon after became the UUSR (Not because of the firearm), a few did make their way into Russian inventory.  This is likely not one of those.  Feeds from mosin stripper clips.",
+    "weight": "4200 g",
+    "volume": "3220 ml",
+    "longest_side": "1175 mm",
+    "barrel_length": "710 mm",
+    "price": "6000 USD",
+    "price_postapoc": "15 USD",
+    "to_hit": -1,
+    "material": [ "steel", "wood" ],
+    "ammo": [ "762R" ],
+    "dispersion": 70,
+    "durability": 10,
+    "blackpowder_tolerance": 48,
+    "clip_size": 5,
+    "flags": [ "RELOAD_ONE", "NO_TURRET", "EASY_CLEAN" ],
+    "pocket_data": [
+      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "762R": 5 }, "allowed_speedloaders": [ "762R_clip" ] }
+    ],
+    "melee_damage": { "bash": 12 }
+  }
+]

--- a/Unlisted Firearms/Rifles/Russian 1895.json
+++ b/Unlisted Firearms/Rifles/Russian 1895.json
@@ -25,7 +25,7 @@
     ],
     "id": "russian_1895",
     "looks_like": "modular_ar15",
-    "description": "The Winchester 1895 was a revolutionary lever action rifle by none other than John Browning.  It was able to fire spitzer bullets unlike most lever actions due to its box magazine.  After rejection from the US Army, a contract to make them in 7.62x54mmR was in order.  While Russia soon after became the UUSR (Not because of the firearm), a few did make their way into Russian inventory.  This is likely not one of those.  Feeds from mosin stripper clips.",
+    "description": "The Winchester 1895 was a revolutionary lever action rifle by none other than John Browning.  It was able to fire spitzer bullets unlike most lever actions due to its box magazine.  After rejection from the US Army, a contract to make them in 7.62x54mmR was in order.  While Russia soon after became the USSR (Not because of the firearm), a few did make their way into Russian inventory.  This is likely not one of those.  Feeds from mosin stripper clips.",
     "weight": "4200 g",
     "volume": "3220 ml",
     "longest_side": "1175 mm",

--- a/Unlisted Firearms/Rifles/SKS-M.json
+++ b/Unlisted Firearms/Rifles/SKS-M.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "sksm",
+    "copy-from": "rifle_semi",
+    "looks_like": "modular_ar15",
+    "type": "GUN",
+    "name": { "str": "SKS-M" },
+    "description": "An odd hybrid between an SKS and an AKM, this Chinese rifle is an SKS that's been outfitted with the ability to feed from AKM magazines.  The best of both worlds!",
+    "variant_type": "gun",
+    "ascii_picture": "sks",
+    "weight": "3850 g",
+    "volume": "2838 ml",
+    "longest_side": "103 cm",
+    "barrel_length": "520 mm",
+    "price": "380 USD",
+    "price_postapoc": "35 USD",
+    "to_hit": -1,
+    "material": [ "steel", "wood" ],
+    "color": "brown",
+    "ammo": [ "762" ],
+    "dispersion": 90,
+    "durability": 8,
+    "min_cycle_recoil": 1832,
+    "barrel_volume": "500 ml",
+    "built_in_mods": [ "inter_bayonet" ],
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "brass catcher", 1 ],
+      [ "grip", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock mount", 1 ],
+      [ "stock accessory", 2 ],
+      [ "underbarrel", 1 ]
+    ],
+    "weapon_category": [ "AUTOMATIC_RIFLES" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "akmag30", "akmag10", "akmag20", "akmag40", "akdrum75" ] } ],
+    "melee_damage": { "bash": 12 }
+  }
+]


### PR DESCRIPTION
The SKS-M is a chinese SKS that can accept AK magazines, and the Russian 1895 which is a lever action 7.62x54mmR. Doesn't function much different than a Mosin but it's historically cool
![image](https://github.com/user-attachments/assets/3c5b5fb4-c6a7-48f5-92bc-04b77338212d)
